### PR TITLE
category_nameの登録

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -16,50 +16,34 @@ class IdeasController < ApplicationController
     @category = Category.new(category_params)
     @idea = Idea.new(idea_params)
 
-    # if Category.exists?(name: @category.name)
-    #   @categoryId = Category.find_by(name: @category.name).select('id')
-    #   @idea.category_id = @categoryId
+    # 新規category_nameがすでにcategoriesテーブルに存在する場合
+    if Category.exists?(name: category_params[:name])
+      @categoryId = Category.find_by(name: category_params[:name]).id
+      @idea.category_id = @categoryId
 
-    if @idea.save && @category.save
-      # ステータスコード201を返す
-      head :created
+      if @idea.save
+        # idea_nameの登録が成功したらステータスコード201を返す
+        head :created
+      else
+        # idea_nameの登録が失敗したらステータスコード422を返す（バリデーションエラー時）
+        head :unprocessable_entity
+      end
+    
+    # 新規category_nameがすでにcategoriesテーブルに存在しない場合
     else
-      # ステータスコード422を返す（バリデーションエラー時）
-      head :unprocessable_entity
+      # categoriesテーブルをidの小さい順に並べて最後のidを取得し、それに+1したidを新規category_nameに付与。
+      # 配列の形で格納されているのでlastメソッドで最後の値を取得
+      @lastCategoryId = Category.order('id DESC').limit(1).ids.last
+      @idea.category_id = @lastCategoryId + 1
+      if @idea.save && @category.save
+        # idea_nameの登録が成功したらステータスコード201を返す
+        head :created
+      else
+        # idea_nameの登録が失敗したらステータスコード422を返す（バリデーションエラー時）
+        head :unprocessable_entity
+      end
     end
   binding.pry
-    # # すでにそのcategory_nameがcategoriesテーブルのnameカラムに存在する場合
-    # if Category.exists?(name: category_params[:name])
-
-    #   # 登録しようとしてるcategory名と一致するcategory名をcategoriesテーブルから検索して探す
-    #   @categoryId = Category.find_by(name: category_params[:name]).select('id')
-
-    #   @idea = Idea.new(idea_params)
-
-    #   if @idea.save && @categoryId.save
-    #     # ステータスコード201を返す
-    #     head :created
-    #   else
-    #     # ステータスコード422を返す（バリデーションエラー時）
-    #     head :unprocessable_entity
-    #   end
-
-    # # まだそのcategory_nameがcategoriesテーブルのnameカラムに存在してない場合
-    # else 
-
-    #   # 新たなcategoryとしてcategoriesテーブルに登録し、ideasテーブルに登録する
-    #   @category = Category.new(category_params)
-    #   @idea = Idea.new(idea_params)
-
-    #   if @category.save && @idea.save
-    #     # ステータスコード201を返す
-    #     head :created
-    #   else
-    #     # ステータスコード422を返す（バリデーションエラー時）
-    #     head :unprocessable_entity
-    #   end
-
-    # end
 
   end
 

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -12,7 +12,6 @@ class IdeasController < ApplicationController
   
   def create
 
-  binding.pry
     @category = Category.new(category_params)
     @idea = Idea.new(idea_params)
 
@@ -29,12 +28,13 @@ class IdeasController < ApplicationController
         head :unprocessable_entity
       end
     
-    # 新規category_nameがすでにcategoriesテーブルに存在しない場合
+    # 新規category_nameがまだcategoriesテーブルに存在していない場合
     else
       # categoriesテーブルをidの小さい順に並べて最後のidを取得し、それに+1したidを新規category_nameに付与。
       # 配列の形で格納されているのでlastメソッドで最後の値を取得
-      @lastCategoryId = Category.order('id DESC').limit(1).ids.last
+      @lastCategoryId = Category.order('name DESC').limit(1).ids.last
       @idea.category_id = @lastCategoryId + 1
+
       if @idea.save && @category.save
         # idea_nameの登録が成功したらステータスコード201を返す
         head :created
@@ -43,7 +43,6 @@ class IdeasController < ApplicationController
         head :unprocessable_entity
       end
     end
-  binding.pry
 
   end
 


### PR DESCRIPTION
# What
新しくcategory_nameを追加する時、それがすでにcategoriesテーブルにある場合は、そのcategory_nameのidをcategory_idとして付与し、まだそのcategory_nameは存在しない場合は、新規category_nameとして登録される条件分岐をideas_controller.rbに記述した。

# 学習したこと
- gem 'pry-rails'を使ってデバッグし、paramsやインスタンス変数の中身を確認できる。
- Githubのissueを使うと、問題解決のプロセスを可視化することができる。

# まだわからないこと
- 下記の部分の`('name DESC')`を名前の降順ではなく、created_atの降順やidの降順にすると、category_nameを登録できないのはなぜか。binding pryでデバッグしたが、その結果は変わらなかったはずなのに。

```ruby:ideas_controller.rb
@lastCategoryId = Category.order('name DESC').limit(1).ids.last
```